### PR TITLE
Pin Mathics3 before 10 until we support 10.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 description = "Notebook integration for Mathics3"
 dependencies = [
-    "Mathics3 >= 7.0.0",
+    "Mathics3 >=7.0,<10.0.0",
     "setuptools",
 ]
 license = {text = "GPL"}


### PR DESCRIPTION
Until we get Mathics3 10.0.0 supported, we need to pin Mathics3 before <10.0.0