### PR TITLE
Updates for Mathics3 10.0...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,11 +81,12 @@ target/
 # IPython
 profile_default/
 ipython_config.py
+*.ipynb
 
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
-# Mathics3 notebook frontends
+# Mathics3 Module for notebook frontends
 
 This library provides helper functions for integrating Mathics3 into notebook environments.
 Currently, it supports Jupyter(Lite), marimo, and Observable.
 
-## Jupyter and JupyterLite
+## JupyterLite
 
-See the [Mathics3 live](https://github.com/Mathics3/Mathics3-live) project for a live demo.
+See [Mathics3 live](https://github.com/Mathics3/Mathics3-live) project a project that
+uses this Python module in a live demo running under pyodidie.
 
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
 ```
 %load_ext mathics3_kernel.frontend.jupyter
 ```

--- a/mathics3_kernel/frontend/format.py
+++ b/mathics3_kernel/frontend/format.py
@@ -1,10 +1,12 @@
-from typing import Callable
+from typing import Callable, Dict, Final
 
 from mathics.core.atoms import SymbolString
 from mathics.core.expression import BoxError, Expression
 from mathics.core.symbols import Symbol
 from mathics.core.systemsymbols import (
+    SymbolAborted,
     SymbolCompiledFunction,
+    SymbolFailed,
     SymbolFullForm,
     SymbolGraphics,
     SymbolGraphics3D,
@@ -16,17 +18,22 @@ from mathics.core.systemsymbols import (
 )
 from mathics.session import get_settings_value
 
-
-FORM_TO_FORMAT = {
-    "System`MathMLForm": "xml",
-    "System`TeXForm": "tex",
+# Maps a Form to a kind of html format.
+# text is the usual text-kind of output.
+# LaTeX is handled by MathJaX display mode $$ $$
+# MathML could be tagged differently too.
+FORM_TO_HTML_TAG_FORMAT: Final[Dict[str, str]] = {
     "System`FullForm": "text",
+    "System`InputForm": "text",
+    # "System`MathMLForm": "MathML",
     "System`OutputForm": "text",
+    "System`TeXForm": "LaTeX",
+    "System`String": "text",
 }
 
 
 class Formatter:
-    def format_output(self, evaluation, expr, format="unformatted"):
+    def format_output(self, evaluation, expr, html_tag_format: str = "unformatted"):
         """
         evaluation.py format_output() from which this was derived is similar but
         it can't make use of a front-ends specific capabilities.
@@ -47,10 +54,16 @@ class Formatter:
                     )
             return boxes
 
-        if isinstance(format, dict):
+        if isinstance(html_tag_format, dict):
             return dict(
-                (k, self.format_output(evaluation, expr, f)) for k, f in format.items()
+                (k, self.format_output(evaluation, expr, f))
+                for k, f in html_tag_format.items()
             )
+
+        if expr is SymbolAborted:
+            return "$Aborted"
+        elif expr is SymbolFailed:
+            return "$Failed"
 
         # For some expressions, we want formatting to be different.
         # In particular for FullForm output, we don't want MathML, we want
@@ -60,7 +73,7 @@ class Formatter:
         expr_head = expr.get_head()
         if expr_head in (SymbolMathMLForm, SymbolTeXForm):
             # For these forms, we strip off the outer "Form" part
-            format = FORM_TO_FORMAT[expr_type]
+            html_tag_format = FORM_TO_HTML_TAG_FORMAT[expr_type]
             elements = expr.get_elements()
             if len(elements) == 1:
                 expr = elements[0]
@@ -79,20 +92,20 @@ class Formatter:
             evaluation.definitions, "Settings`$QuotedStrings"
         )
 
-        if format == "text":
-            result = expr.format(evaluation, SymbolOutputForm)
-            result = eval_boxes(result, result.boxes_to_text, evaluation)
+        if html_tag_format == "text":
+            boxed = expr.format(evaluation, SymbolOutputForm)
+            result = eval_boxes(boxed, boxed.boxes_to_text, evaluation)
 
             if use_quotes:
                 result = '"' + result + '"'
 
             return self.text(result)
-        elif format == "xml":
+        elif html_tag_format == "xml":
             result = Expression(SymbolStandardForm, expr).format(
                 evaluation, SymbolMathMLForm
             )
             return self.html(eval_boxes(result, result.boxes_to_text, evaluation))
-        elif format == "tex":
+        elif html_tag_format == "tex":
             result = Expression(SymbolStandardForm, expr).format(
                 evaluation, SymbolTeXForm
             )

--- a/mathics3_kernel/frontend/jupyter.py
+++ b/mathics3_kernel/frontend/jupyter.py
@@ -5,9 +5,11 @@ from IPython.core.interactiveshell import InteractiveShell
 from IPython.core.magic import Magics, magics_class, line_cell_magic
 
 from mathics.session import MathicsSession
+from mathics.core.load_builtin import import_and_load_builtins
 
 from .format import Formatter
 
+import_and_load_builtins()
 
 class JupyterFormatter(Formatter):
     def text(self, result):

--- a/mathics3_kernel/frontend/jupyter.py
+++ b/mathics3_kernel/frontend/jupyter.py
@@ -38,6 +38,7 @@ class MathicsMagic(Magics):
     def __init__(self, shell):
         super().__init__(shell)
         self.session = MathicsSession()
+        import_and_load_builtins()
         self.formatter = JupyterFormatter()
 
     @line_cell_magic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,25 +1,53 @@
 [build-system]
 requires = [
-    "setuptools>=70.0.0", # CVE-2024-38335 recommends this
+    "setuptools>=80", # CVE-2024-38335 and later CVE's recommend this
+    "wheel",
     "packaging",
 ]
 build-backend = "setuptools.build_meta"
 
 [project]
-description = "Notebook integration for Mathics3"
+description = "Jupyter, JupyterLite, marimo, Observable Notebook integration for Mathics3"
 dependencies = [
-    "Mathics3 >= 7.0.0",
+    "Mathics3 >= 10.0.0",
     "setuptools",
+    # The following is needed because latest versions of "chardet" (6.0
+    # and above) are not supported with some versions of "requests". I
+    # think the main important version restriction below is chardet<6.0.0
+    # chardet 6+ and above is not compatible with "requests" (et. al?)
+    "requests>=2.32.3",
+    "urllib3>=1.21.1,< 3",
+    "chardet>=3.0.2,< 6.0.0",
+    "charset-normalizer>=2.0.0,< 4.0.0",
 ]
-license = {text = "GPL"}
-name = "Mathics3-notebook-frontends"
+license = "GPL-3.0-or-later"
+name = "mathics3_notebook_frontends"
+requires-python = ">=3.11"
 maintainers = [
-    {name = "Mathics Group", email = "mathics-devel@googlegroups.com"},
+    {name = "Mathics3 Group", email = "mathics-devel@googlegroups.com"},
 ]
-version = "0.1.0"
+classifiers = [
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "Topic :: Scientific/Engineering :: Physics",
+    "Topic :: Software Development :: Interpreters",
+]
+version = "1.0.0"
 
 [project.urls]
 Homepage = "https://mathics.org/"
+Downloads = "https://github.com/Mathics3/Mathics3-notebook-frontends/releases"
+
+[[tool.mypy.overrides]]
+ignore_missing_imports = true
 
 [tool.setuptools.packages.find]
 include = ["mathics3_kernel.frontend"]


### PR DESCRIPTION
README.md: Removed jupyter section and narrowed information to jypyterLite. This code does not work with Jupyter (yet). We will add this section when it works

.gitignore: more ignore: Jupyter notebooks and .python-version

mathics3_kernel/frontend/jupyter.py: The crucial addition: adding explicit load module import needed now in the 10.x API.

pyproject.toml: go over. Add the chardet version pin dance that's now needed.